### PR TITLE
Update schema for multiple alias and previous names

### DIFF
--- a/docs/schemas/person_name.json
+++ b/docs/schemas/person_name.json
@@ -7,42 +7,45 @@
   "properties": {
     "alias": {
       "description": "Another name that the person is known by. This might be a nickname, former name, or a name that the person is also known as (aka).",
-      "type": "object",
-      "unevaluatedProperties": false,
-      "anyOf": [
-         {
-           "required": [
-             "fullNameAlias"
-           ]
-         },
-         {
-           "required": [
-            "lastNameAlias"
-           ]
-         } 
-      ],
-      "properties": {
-        "fullNameAlias": {
-          "$ref": "#/$defs/NameValue",
-          "description": "The full name of the person"
-        },
-        "firstNameAlias": {
-          "$ref": "#/$defs/NameValue",
-          "description": "The first name of the person; this may consist of more than one word "
-        },
-        "givenNamesAlias": {
-          "$ref": "#/$defs/NameValue",
-          "description": "The parts of the full name that preceed the last name"
-        },
-        "lastNameAlias": {
-          "$ref": "#/$defs/NameValue",
-          "description": "The last name of the person; this may consist of more than one word "
-        },
-		"middleNamesAlias": {
-          "$ref": "#/$defs/NameValue",
-          "description": "Middle or additional names supplied between the First name and Last name, separated by spaces "
-        }
-     }
+      "type": "array",
+      "items": {
+        "type": "object",
+        "unevaluatedProperties": false,
+        "anyOf": [
+           {
+             "required": [
+               "fullNameAlias"
+             ]
+           },
+           {
+             "required": [
+              "lastNameAlias"
+             ]
+           } 
+        ],
+        "properties": {
+          "fullNameAlias": {
+            "$ref": "#/$defs/NameValue",
+            "description": "The full name of the person"
+          },
+          "firstNameAlias": {
+            "$ref": "#/$defs/NameValue",
+            "description": "The first name of the person; this may consist of more than one word "
+          },
+          "givenNamesAlias": {
+            "$ref": "#/$defs/NameValue",
+            "description": "The parts of the full name that preceed the last name"
+          },
+          "lastNameAlias": {
+            "$ref": "#/$defs/NameValue",
+            "description": "The last name of the person; this may consist of more than one word "
+          },
+          "middleNamesAlias": {
+            "$ref": "#/$defs/NameValue",
+            "description": "Middle or additional names supplied between the First name and Last name, separated by spaces "
+	  }
+	}
+      }
     },
     "previous": {
       "description": "A name that the person has used in the past.",

--- a/docs/schemas/person_name.json
+++ b/docs/schemas/person_name.json
@@ -46,40 +46,43 @@
     },
     "previous": {
       "description": "A name that the person has used in the past.",
-      "type": "object",
-      "unevaluatedProperties": false,
-      "anyOf": [
-         {
-           "required": [
-             "fullNamePrevious"
-           ]
-         },
-         {
-           "required": [
-            "lastNamePrevious"
-           ]
-         } 
-      ],
-      "properties": {
-        "fullNamePrevious": {
-          "$ref": "#/$defs/NameValue",
-          "description": "The full name of the person"
-        },
-        "firstNamePrevious": {
-          "$ref": "#/$defs/NameValue",
-          "description": "The first name of the person; this may consist of more than one word "
-        },
-        "givenNamesPrevious": {
-          "$ref": "#/$defs/NameValue",
-          "description": "The parts of the full name that preceed the last name"
-        },
-        "lastNamePrevious": {
-          "$ref": "#/$defs/NameValue",
-          "description": "The last name of the person; this may consist of more than one word "
-        },
-        "middleNamesPrevious": {
-          "$ref": "#/$defs/NameValue",
-          "description": "Middle or additional names supplied between the First name and Last name, separated by spaces "
+      "type": "array",
+      "items": {
+        "type": "object",
+        "unevaluatedProperties": false,
+        "anyOf": [
+           {
+             "required": [
+               "fullNamePrevious"
+             ]
+           },
+           {
+             "required": [
+              "lastNamePrevious"
+             ]
+           } 
+        ],
+        "properties": {
+          "fullNamePrevious": {
+            "$ref": "#/$defs/NameValue",
+            "description": "The full name of the person"
+          },
+          "firstNamePrevious": {
+            "$ref": "#/$defs/NameValue",
+            "description": "The first name of the person; this may consist of more than one word "
+          },
+          "givenNamesPrevious": {
+            "$ref": "#/$defs/NameValue",
+            "description": "The parts of the full name that preceed the last name"
+          },
+          "lastNamePrevious": {
+            "$ref": "#/$defs/NameValue",
+            "description": "The last name of the person; this may consist of more than one word "
+          },
+          "middleNamesPrevious": {
+            "$ref": "#/$defs/NameValue",
+            "description": "Middle or additional names supplied between the First name and Last name, separated by spaces "
+          }
         }
       }
     },

--- a/docs/schemas/person_name_example_1.json
+++ b/docs/schemas/person_name_example_1.json
@@ -5,9 +5,10 @@
           lastNameLegal:"Yola",
           middleNamesLegal:"At̕łi"
           },
-  alias: {fullNameAlias:"Atli Yola , M.D.",
+  alias: [{fullNameAlias:"Atli Yola , M.D.",
           firstNameAlias:"Atli",
           givenNamesAlias:"Atli",
           lastNameAlias:"Yola"         
-          }
+          },
+          {fullNameAlias:"Pesk'a Yola"}]
 }

--- a/docs/schemas/person_name_example_2.json
+++ b/docs/schemas/person_name_example_2.json
@@ -9,8 +9,8 @@
   preferred:{fullNamePreferred:"Mike Dunham-Wilkie",
           firstNamePreferred:"Mike"
           },
-  previous:{fullNamePrevious:"Michael Stuart David Wilkie",
+  previous:[{fullNamePrevious:"Michael Stuart David Wilkie",
           firstNamePrevious:"Michael",
           lastNamePrevious:"Wilkie"         
-          }
+          }]
 }


### PR DESCRIPTION
This pull request attempts to resolve:
- https://github.com/bcgov/inclusive-names-service/issues/14

# What's included

- Update to `person_name.json` schema, specifically to change `alias` and `previous` to support multiple names.
- Updates to the 2 JSON example files to validate with the updated schema

# Note

I don't know my way around JSON schema, so please review these changes critically.

I have tested the schema and example documents using https://www.jsonschemavalidator.net

Your feedback is appreciated.