### PR TITLE
Fix link to AnyAscii

### DIFF
--- a/docs/comparing/anyascii/README.md
+++ b/docs/comparing/anyascii/README.md
@@ -1,6 +1,6 @@
 # Representing Unicode Text Using ASCII
 
-Some systems support only [ASCII](../../glossary.md#ascii) and not Unicode. For these it is sometimes helpful to be able to create a simplified (ASCII only) version of the Unicode string in a consistent manner. The [anyASCII](www.anyascii.com) algorithm provides a mechanism for doing this. This [geeksforgeeks](https://www.geeksforgeeks.org/convert-unicode-to-ascii-in-python/) article provides some good information.
+Some systems support only [ASCII](../../glossary.md#ascii) and not Unicode. For these it is sometimes helpful to be able to create a simplified (ASCII only) version of the Unicode string in a consistent manner. The [anyASCII](https://anyascii.com) algorithm provides a mechanism for doing this. This [geeksforgeeks](https://www.geeksforgeeks.org/convert-unicode-to-ascii-in-python/) article provides some good information.
 
 ## Program Example of using AnyASCII
 


### PR DESCRIPTION
The markdown link was formatted as a relative link, so pointing to `https://developer.gov.bc.ca/catalog/default/component/indigenous-languages-in-systems/docs/www.anyascii.com` instead of `https://anyascii.com`.

Also, `www.anyascii.com` redirects to drop the `www.`, so I removed that as well.

This can be seen at https://developer.gov.bc.ca/catalog/default/component/indigenous-languages-in-systems/docs/comparing/anyascii/