### PR TITLE
Update schema for multiple alias and previous names

### DIFF
--- a/docs/schemas/person_name.json
+++ b/docs/schemas/person_name.json
@@ -46,40 +46,43 @@
     },
     "previous": {
       "description": "A name that the person has used in the past.",
-      "type": "object",
-      "unevaluatedProperties": false,
-      "anyOf": [
-         {
-           "required": [
-             "pnFullNamePrevious"
-           ]
-         },
-         {
-           "required": [
-            "pnLastNamePrevious"
-           ]
-         } 
-      ],
-      "properties": {
-        "pnFullNamePrevious": {
-          "$ref": "#/$defs/NameValue",
-          "description": "The full name of the person"
-        },
-        "pnFirstNamePrevious": {
-          "$ref": "#/$defs/NameValue",
-          "description": "The first name of the person; this may consist of more than one word "
-        },
-        "pnGivenNamesPrevious": {
-          "$ref": "#/$defs/NameValue",
-          "description": "The parts of the full name that preceed the last name"
-        },
-        "pnLastNamePrevious": {
-          "$ref": "#/$defs/NameValue",
-          "description": "The last name of the person; this may consist of more than one word "
-        },
-        "pnMiddleNamesPrevious": {
-          "$ref": "#/$defs/NameValue",
-          "description": "Middle or additional names supplied between the First name and Last name, separated by spaces "
+      "type": "array",
+      "items": {
+        "type": "object",
+        "unevaluatedProperties": false,
+        "anyOf": [
+           {
+             "required": [
+               "pnFullNamePrevious"
+             ]
+           },
+           {
+             "required": [
+              "pnLastNamePrevious"
+             ]
+           } 
+        ],
+        "properties": {
+          "pnFullNamePrevious": {
+            "$ref": "#/$defs/NameValue",
+            "description": "The full name of the person"
+          },
+          "pnFirstNamePrevious": {
+            "$ref": "#/$defs/NameValue",
+            "description": "The first name of the person; this may consist of more than one word "
+          },
+          "pnGivenNamesPrevious": {
+            "$ref": "#/$defs/NameValue",
+            "description": "The parts of the full name that preceed the last name"
+          },
+          "pnLastNamePrevious": {
+            "$ref": "#/$defs/NameValue",
+            "description": "The last name of the person; this may consist of more than one word "
+          },
+          "pnMiddleNamesPrevious": {
+            "$ref": "#/$defs/NameValue",
+            "description": "Middle or additional names supplied between the First name and Last name, separated by spaces "
+          }
         }
       }
     },
@@ -120,7 +123,7 @@
           "$ref": "#/$defs/NameValue",
           "description": "Middle or additional names supplied between the First name and Last name, separated by spaces "
         }
-      },
+      }
 	},
     "wholelegal": {
       "description": "A name that identifies the person for legal, administrative and other official purposes. This person name type is used for people with Indigenous language names, possibly containing Unicode characters not found in ASCII. ",

--- a/docs/schemas/person_name.json
+++ b/docs/schemas/person_name.json
@@ -7,40 +7,43 @@
   "properties": {
     "alias": {
       "description": "Another name that the person is known by. This might be a nickname, former name, or a name that the person is also known as (aka).",
-      "type": "object",
-      "unevaluatedProperties": false,
-      "anyOf": [
-         {
-           "required": [
-             "pnFullNameAlias"
-           ]
-         },
-         {
-           "required": [
-            "pnLastNameAlias"
-           ]
-         } 
-      ],
-      "properties": {
-        "pnFullNameAlias": {
-          "$ref": "#/$defs/NameValue",
-          "description": "The full name of the person"
-        },
-        "pnFirstNameAlias": {
-          "$ref": "#/$defs/NameValue",
-          "description": "The first name of the person; this may consist of more than one word "
-        },
-        "pnGivenNamesAlias": {
-          "$ref": "#/$defs/NameValue",
-          "description": "The parts of the full name that preceed the last name"
-        },
-        "pnLastNameAlias": {
-          "$ref": "#/$defs/NameValue",
-          "description": "The last name of the person; this may consist of more than one word "
-        },
-		"pnMiddleNamesAlias": {
-          "$ref": "#/$defs/NameValue",
-          "description": "Middle or additional names supplied between the First name and Last name, separated by spaces "
+      "type": "array",
+      "items": {
+        "type": "object",
+        "unevaluatedProperties": false,
+        "anyOf": [
+           {
+             "required": [
+               "pnFullNameAlias"
+             ]
+           },
+           {
+             "required": [
+              "pnLastNameAlias"
+             ]
+           } 
+        ],
+        "properties": {
+          "pnFullNameAlias": {
+            "$ref": "#/$defs/NameValue",
+            "description": "The full name of the person"
+          },
+          "pnFirstNameAlias": {
+            "$ref": "#/$defs/NameValue",
+            "description": "The first name of the person; this may consist of more than one word "
+          },
+          "pnGivenNamesAlias": {
+            "$ref": "#/$defs/NameValue",
+            "description": "The parts of the full name that preceed the last name"
+          },
+          "pnLastNameAlias": {
+            "$ref": "#/$defs/NameValue",
+            "description": "The last name of the person; this may consist of more than one word "
+          },
+		  "pnMiddleNamesAlias": {
+            "$ref": "#/$defs/NameValue",
+            "description": "Middle or additional names supplied between the First name and Last name, separated by spaces "
+          }
         }
      }
     },

--- a/docs/schemas/person_name_examples/person_name_example_2.json
+++ b/docs/schemas/person_name_examples/person_name_example_2.json
@@ -11,14 +11,16 @@
   preferred:{pnFullNamePreferred:"Sandy Lee",
           pnFirstNamePreferred:"Sandy Lee"
           },
-  previous:{pnFullNamePrevious:"Sandra Lee Mason",
-          pnFirstNamePrevious:"Sandra",
-		  pnMiddleNamesPrevious:"Lee",
-          pnLastNamePrevious:"Mason"         
-          },
-  previous:{pnFullNamePrevious:"Alex Lee Mason",
-          pnFirstNamePrevious:"Alex",
-		  pnMiddleNamesPrevious:"Lee",
-          pnLastNamePrevious:"Mason"         
-          }
+  previous: [
+                    {pnFullNamePrevious:"Sandra Lee Mason",
+                    pnFirstNamePrevious:"Sandra",
+		            pnMiddleNamesPrevious:"Lee",
+                    pnLastNamePrevious:"Mason"         
+                    },
+                    {pnFullNamePrevious:"Alex Lee Mason",
+                    pnFirstNamePrevious:"Alex",
+		            pnMiddleNamesPrevious:"Lee",
+                    pnLastNamePrevious:"Mason"         
+                    }
+          ]
 }

--- a/docs/schemas/person_name_examples/person_name_example_2.json
+++ b/docs/schemas/person_name_examples/person_name_example_2.json
@@ -5,9 +5,9 @@
           pnMiddleNamesLegal:"Lee",
           pnLastNameLegal:"Lenius"
           },
-  alias: {pnFullNameAlias:"Sandy Lee",
+  alias: [{pnFullNameAlias:"Sandy Lee",
           pnFirstNameAlias:"Sandy Lee"
-          },
+          }],
   preferred:{pnFullNamePreferred:"Sandy Lee",
           pnFirstNamePreferred:"Sandy Lee"
           },

--- a/docs/schemas/person_name_examples/person_name_example_4.json
+++ b/docs/schemas/person_name_examples/person_name_example_4.json
@@ -9,8 +9,10 @@
   preferred:{pnFullNamePreferred:"ᐃᐧᑲᐢᐠᐊᐧ",
           pnFirstNamePreferred:"ᐃᐧᑲᐢᐠᐊᐧ"
           },
-  previous:{pnFullNamePrevious:"Ira Williams",
+  previous:[
+          {pnFullNamePrevious:"Ira Williams",
           pnFirstNamePrevious:"Iraᐧ",
           pnLastNamePrevious:"Williamsᐧ"
           }
+          ]
 }


### PR DESCRIPTION
This pull request attempts to resolve:
- https://github.com/bcgov/inclusive-names-service/issues/14

# What's included

- Update to `person_name.json` schema, specifically to change `alias` and `previous` to support multiple names.
- Updates to the JSON example files to validate with the updated schema

# Note

I don't know my way around JSON schema, so please review these changes critically.

I have tested the schema and example documents using https://www.jsonschemavalidator.net

Your feedback is appreciated.

This is another attempt at pull request #15.