### PR TITLE
Remove git artifacts from documentation pages

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -1,4 +1,3 @@
-<<<<<<< HEAD
 ![Lifecycle:Experimental](images/Lifecycle-Experimental-339999.svg)
 
 # Techniques for Supporting Indigenous Language Text in Computer Systems

--- a/docs/test_data/Readme.md
+++ b/docs/test_data/Readme.md
@@ -1,4 +1,3 @@
-<<<<<<< HEAD
 
 
 The following files can be used in testing systems for Indigenous language support:


### PR DESCRIPTION
This removes two errant git `<<<<<<< HEAD` lines from the ILTS documentation pages, seen here:

<img width="3312" height="1882" alt="Screenshot 2026-04-22 at 11 34 31 AM" src="https://github.com/user-attachments/assets/4a7a6f31-c7e8-4ad8-905a-ac8d645c9076" />

<img width="3312" height="1882" alt="Screenshot 2026-04-22 at 11 35 47 AM" src="https://github.com/user-attachments/assets/330e097c-4a00-41f8-ab0d-6a265c581f5c" />
